### PR TITLE
Change cache ttl to 30 seconds

### DIFF
--- a/app/Traits/ApiResponser.php
+++ b/app/Traits/ApiResponser.php
@@ -120,7 +120,7 @@ trait ApiResponser
 
 		$fullUrl = "{$url}?{$queryString}";
 
-		return Cache::remember($fullUrl, 30/60, function() use($data) {
+		return Cache::remember($fullUrl, 30, function() use($data) {
 			return $data;
 		});
 	}


### PR DESCRIPTION
In Laravel 5.8 release ttl parameter unit have been changed from minutes to seconds
https://www.whileifblog.com/2019/02/09/cache-ttl-change-coming-to-laravel-5-8/